### PR TITLE
Fix - Fetch user data on successful sign-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ crashlytics-build.properties
 
 # Crash dumps
 mono_crash.*.*.json
+/.idea

--- a/Assets/SphereOne/Examples/Scenes/DemoScene.unity
+++ b/Assets/SphereOne/Examples/Scenes/DemoScene.unity
@@ -2492,7 +2492,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2973761112392359052, guid: 7250817c851cf410592b404cbfd55364, type: 3}
       propertyPath: _apiKey
-      value: 9c16a688-7b07-4ef1-a5ef-ae7b220730c1
+      value: 5cfaf71f-4ac3-4ca6-963e-36bcb43fc1f9
       objectReference: {fileID: 0}
     - target: {fileID: 2973761112392359052, guid: 7250817c851cf410592b404cbfd55364, type: 3}
       propertyPath: _scheme
@@ -2500,7 +2500,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2973761112392359052, guid: 7250817c851cf410592b404cbfd55364, type: 3}
       propertyPath: _clientId
-      value: 7af3b27c-e2e9-48e6-8cd8-3136626d55a9
+      value: 8a983c52-8011-4ad4-8d8a-903a6c8dd37c
       objectReference: {fileID: 0}
     - target: {fileID: 2973761112392359052, guid: 7250817c851cf410592b404cbfd55364, type: 3}
       propertyPath: _debugText
@@ -2516,7 +2516,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2973761112392359052, guid: 7250817c851cf410592b404cbfd55364, type: 3}
       propertyPath: _redirectUrl
-      value: https://localhost:3000
+      value: http://localhost:3000
       objectReference: {fileID: 0}
     - target: {fileID: 2973761112392359052, guid: 7250817c851cf410592b404cbfd55364, type: 3}
       propertyPath: _clientSecret

--- a/Assets/SphereOne/Scripts/SphereOneManager.cs
+++ b/Assets/SphereOne/Scripts/SphereOneManager.cs
@@ -56,8 +56,8 @@ namespace SphereOne
         const string LOCAL_STORAGE_CREDENTIALS = "sphere_one_credentials";
         const string LOCAL_STORAGE_STATE = "sphere_one_state";
 
-        const string DOMAIN = "https://relaxed-kirch-zjpimqs5qe.projects.oryapis.com";
-        const string AUDIENCE = "https://relaxed-kirch-zjpimqs5qe.projects.oryapis.com";
+        const string DOMAIN = "https://auth.sphereone.xyz";
+        const string AUDIENCE = "https://auth.sphereone.xyz";
         const string IFRAME_URL = "https://wallet.sphereone.xyz";
 
         [SerializeField] Environment _environment = Environment.PRODUCTION;

--- a/Assets/SphereOne/Scripts/SphereOneManager.cs
+++ b/Assets/SphereOne/Scripts/SphereOneManager.cs
@@ -240,10 +240,7 @@ namespace SphereOne
                 return;
 
             var credentials = JsonConvert.DeserializeObject<CredentialsWrapper>(res).data;
-            if (!string.IsNullOrEmpty(credentials.access_token))
-            {
-                RefreshUserAuthentication(credentials);
-            }
+            LoadCredentials(credentials);
         }
 
         // Do not rename this function without updating sphereone.jslib and/or bridge.js
@@ -435,7 +432,15 @@ namespace SphereOne
             if (credentials == null)
                 return;
 
-            _credentials = credentials;
+            if (!string.IsNullOrEmpty(credentials.access_token))
+            {
+                RefreshUserAuthentication(credentials);
+            }
+            else
+            {
+                _logger.LogError("Error loading credentials");
+                return;
+            }
 
             _logger.Log($"User authenticated.");
 


### PR DESCRIPTION
### **PR Description**

Jira Ticket: `None`

This PR has changes to fix a minor issue on the Unity SDK due to recent changes to remove JWT token check on `createCharge`.

The issue is: there is a `function` -> `LoadCredentials`, which was originally called upon successful login. It got replaced with `RefreshUserAuthentication`, which successfully sets up the `Authorization` header.
That's fine.
But the API calls within `LoadCredentials` -> `FetchAllData` weren't being triggered. This means, we cannot fetch our wallets, user balances, and user document. So, when we open `Wallet` in the `Example/DemoScene` will always be blank, since there's no data to populate.


### **ChangeLogs**

- changed back the `_clientId` back to `SphereOne` for `DemoScene`
- swapped out the `_apiKey` to one of my test merchant accounts for now
- fixed the default redirect url - `https://localhost:3000` - since a `localhost` don't have `https`
- call `LoadCredentials` within `CALLBACK_PopupLoginSuccess` and moved `RefreshUserAuthentication` inside

### **Showcase**

<table>
   <tr>
       <td colspan="2" align="center"><b>Load User Wallets Upon Successful Login</b></td> 
   </tr>
   <tr>
       <td align="center">Issue</td>
   </tr>
   <tr>
       <td align="center"><video src="https://github.com/SphereGlobal/unity-sdk/assets/116052081/3101eb0e-0a67-49c6-a0e2-d11840f276ec" controls="controls" muted="muted"></video></td>
   </tr>
   <tr>
       <td align="center">Fix</td>
   </tr>
   <tr>
       <td align="center"><video src="https://github.com/SphereGlobal/unity-sdk/assets/116052081/f79a29d3-1f09-4ff9-b307-97b3bc6125b8" controls="controls" muted="muted"></video></td>
   </tr>
</table>




