### PR TITLE
ENG-1932 - Added pay/route and other api data types

### DIFF
--- a/Assets/SphereOne/Examples/Scenes/DemoScene.unity
+++ b/Assets/SphereOne/Examples/Scenes/DemoScene.unity
@@ -394,6 +394,140 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 185037384}
   m_CullTransparentMesh: 1
+--- !u!1 &223974226
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 223974227}
+  - component: {fileID: 223974230}
+  - component: {fileID: 223974229}
+  - component: {fileID: 223974228}
+  m_Layer: 5
+  m_Name: Route Estimation
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &223974227
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223974226}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1.0000112, y: 1.0000112, z: 1.0000112}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 782628376}
+  m_Father: {fileID: 829749190}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &223974228
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223974226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 223974229}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 777709094}
+        m_TargetAssemblyTypeName: TestSphereOneManager, Assembly-CSharp
+        m_MethodName: GetRouteEstimation
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &223974229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223974226}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &223974230
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 223974226}
+  m_CullTransparentMesh: 1
 --- !u!1 &334845585
 GameObject:
   m_ObjectHideFlags: 0
@@ -935,6 +1069,44 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c8bcdf4540f5a4ad5af2b9c07bb6b224, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &782628375
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 782628376}
+  - component: {fileID: 782628379}
+  - component: {fileID: 782628378}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &782628376
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 782628375}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 223974227}
+  m_RootOrder: -1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &782628377 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2973761112392359052, guid: 7250817c851cf410592b404cbfd55364, type: 3}
@@ -946,6 +1118,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8f6d37f74c70d484b9a5438d607a7f7b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &782628378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 782628375}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Pay Estimate
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 80
+  m_fontSizeBase: 80
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 0
+  m_fontSizeMax: 0
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 0
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &782628379
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 782628375}
+  m_CullTransparentMesh: 1
 --- !u!1 &829749189
 GameObject:
   m_ObjectHideFlags: 0
@@ -981,6 +1250,7 @@ RectTransform:
   - {fileID: 2001660426}
   - {fileID: 761769923}
   - {fileID: 334845586}
+  - {fileID: 223974227}
   m_Father: {fileID: 1439535357}
   m_RootOrder: -1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/SphereOne/Plugins/sphereone.jslib
+++ b/Assets/SphereOne/Plugins/sphereone.jslib
@@ -52,6 +52,34 @@ var plugin = {
   RequestCredentialFromSlideout: function () {
     window.bridge.requestCredentialFromSlideout();
   },
+
+  OpenAddPinCodePopup: function (url) {
+    const width = 450;
+    const height = 350;
+    const left = (window.innerWidth - width) / 2 + window.screenX;
+    const top = (window.innerHeight - height) / 2 + window.screenY;
+    const options = `width=${width},height=${height},top=${top},left=${left}`;
+
+    const popup = window.open(
+      UTF8ToString(url),
+      'Add Pin Code',
+      options
+    );
+  },
+
+  OpenPinCodePopup: function(url) {
+    const width = 450;
+    const height = 350;
+    const left = (window.innerWidth - width) / 2 + window.screenX;
+    const top = (window.innerHeight - height) / 2 + window.screenY;
+    const options = `width=${width},height=${height},top=${top},left=${left}`;
+
+    const popup = window.open(
+      UTF8ToString(url),
+      'Sphereone Pin Code',
+      options
+    );
+  },
 };
 
 mergeInto(LibraryManager.library, plugin);

--- a/Assets/SphereOne/Scripts/ApiTypes.cs
+++ b/Assets/SphereOne/Scripts/ApiTypes.cs
@@ -85,6 +85,7 @@ namespace SphereOne
         public string countryCode;
         public string countryFlag;
         public bool isMerchant;
+        public bool isPinCodeSetup;
     }
 
     [Serializable]
@@ -540,5 +541,11 @@ namespace SphereOne
         {
             return $"toAmount: {toAmount}\ntoAddress: {toAddress}\ntoChain: {toChain}\ntoToken: {toToken.ToString()}";
         }
+    }
+
+    public class PinCodeSetupResponse
+    {
+        public string data;
+        public string error;
     }
 }

--- a/Assets/SphereOne/Scripts/ApiTypes.cs
+++ b/Assets/SphereOne/Scripts/ApiTypes.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Numerics;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace SphereOne
 {
@@ -43,6 +44,35 @@ namespace SphereOne
         Unknown
     }
 
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum RouteActionType
+    {
+        SWAP,
+        TRANSFER,
+        BRIDGE,
+        Unknown
+    }
+
+    [JsonConverter(typeof(TolerantEnumConverter))]
+    public enum BridgeServices
+    {
+        wormhole,
+        lifi,
+        imx,
+        stealthex,
+        squid,
+        swft
+    }
+
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum TransferType
+    {
+        SYSTEM,
+        ERC20,
+        SPL,
+        Unknown
+    }
+
     [Serializable]
     public class User
     {
@@ -79,6 +109,13 @@ namespace SphereOne
     }
 
     [Serializable]
+    public class UserBalance
+    {
+        public Balance[] balances;
+        public string total;
+    }
+
+    [Serializable]
     public class TokenMetadata
     {
         public string symbol;
@@ -86,7 +123,12 @@ namespace SphereOne
         public int decimals;
         public string address;
         public string logoURI;
-        public string chain;
+        public SupportedChains chain;
+
+        public override string ToString()
+        {
+            return $"symbol: {symbol}\nname: {name}\ndecimals: {decimals}\naddress: {address}\nlogoURI: {logoURI}\nchain: {chain}";
+        }
     }
 
     [Serializable]
@@ -167,17 +209,202 @@ namespace SphereOne
     }
 
     [Serializable]
+    public class ChainWallets : Dictionary<SupportedChains, Wallet>
+    {}
+
+    [Serializable]
+    public class BridgeQuote
+    {
+        public object rawQuote; // 'any' in TypeScript is similar to 'object' in C#
+        public BridgeServices service;
+        public SupportedChains fromChain;
+        public BigInteger fromAmount; // Assuming BigNumber maps to BigInteger
+        public string fromAddress;
+        public TokenMetadata fromToken;
+        public SupportedChains toChain;
+        public BigInteger toAmount; // Assuming BigNumber maps to BigInteger
+        public string toAddress;
+        public TokenMetadata toToken;
+        public double estimatedTime; // Assuming number maps to double
+        public double estimatedCostUSD; // Assuming number maps to double
+        public BigInteger estimatedEthGas; // Assuming BigNumber maps to BigInteger
+        public BigInteger estimatedMatGas; // Assuming BigNumber maps to BigInteger
+        public BigInteger estimatedAvaxGas; // Assuming BigNumber maps to BigInteger
+        public BigInteger estimatedArbGas; // Assuming BigNumber maps to BigInteger
+        public BigInteger estimatedBscGas; // Assuming BigNumber maps to BigInteger
+        public BigInteger estimatedSolGas; // Assuming BigNumber maps to BigInteger
+        public BigInteger estimatedOptGas; // Assuming BigNumber maps to BigInteger
+        public BigInteger estimatedEosEvmGas; // Assuming BigNumber maps to BigInteger
+        public BigInteger estimatedBaseGas; // Assuming BigNumber maps to BigInteger
+        public string bridgeId; // Can be null due to the '' in TypeScript
+        public string depositAddress; // Can be null due to the '' in TypeScript
+    }
+
+    [Serializable]
+    public class BridgeProps
+    {
+        public BridgeQuote quote;
+        public ChainWallets wallets;
+        public double userSponsoredGas;
+    }
+
+    [Serializable]
+    public class BridgeResponse
+    {
+        public BridgeResponseData data;
+        public string error;
+    }
+
+    [Serializable]
+    public class BridgeResponseData
+    {
+        public BridgeQuote quote;
+        public ChainWallets wallets;
+        public string bridgeTx; // for wormhole this refers to send to bridge tx
+        public string redeemTx; // wormhole only
+        public string approveTx; // lifi only. Sometimes allowance is already there so no need for this
+        public string postVaaTx;
+        public string userOperationHash; // Only with Smart Wallets to poll TxHash later
+        public TxStatus bridgeStatus;
+        public TxStatus redeemStatus; // (wormhole only) when using lifi true by default
+        public TxStatus approveStatus; // (lifi only) when using wormhole true by default
+        public TxStatus status;
+        public string sequence; // wormhole only
+        public string emitterAddress; // wormhole only
+        public string bridgeId; // stealthex/swft only
+        public bool sponsoredFee; // We can sponsor or not with Smart Wallets
+    }
+
+    [Serializable]
+    public class SwapData
+    {
+        public SupportedChains fromChain;
+        public BigInteger fromAmount;
+        public TokenMetadata fromToken;
+        public string fromAddress;
+        public string fromPrivateKey;
+        public BigInteger toAmount;
+        public TokenMetadata toToken;
+        public BigInteger estimatedGas;
+    }
+
+    [Serializable]
+    public class SwapResponse
+    {
+        public SupportedChains fromChain;
+        public string fromPrivateKey;
+        public string fromAddress;
+        public TokenMetadata fromToken;
+        public TokenMetadata toToken;
+        public BigInteger toAmount;
+        public BigInteger fromAmount;
+        public string userOperationHash; // Only valid for smart wallets (is used for retrieving the Tx Hash after bundlers execution)
+        public string approveTxHash; // always null for solana
+        public string swapTxHash;
+        public TxStatus approveStatus;
+        public TxStatus swapStatus;
+        public TxStatus status; // success when approve and status are done
+        public bool sponsoredFee;
+    }
+
+    [Serializable]
+    public class TransferData
+    {
+        public SupportedChains fromChain;
+        public BigInteger fromAmount; // Assuming BigNumber maps to BigInteger
+        public string fromAddress;
+        public string fromPrivateKey;
+        public TokenMetadata fromToken;
+        public string toAddress;
+        public bool smartWallet; // Nullable because of the '' in TypeScript indicating it's optional
+        public string starkPrivateKey; // Can be null due to the '' in TypeScript
+    }
+
+    [Serializable]
+    public class TransferResponseData
+    {
+        public SupportedChains fromChain;
+        public BigInteger fromAmount; // Assuming BigNumber maps to BigInteger
+        public string fromAddress;
+        public string fromTokenAddress;
+        public string toAddress;
+        public string hash; // Can be null
+        public string userOperationHash; // Can be null
+        public string fromPrivateKey;
+        public TransferType transferType;
+        public TxStatus status;
+        public BigInteger fee; // Nullable, assuming BigNumber maps to BigInteger
+        public object rawRecipient; // 'any' in TypeScript is similar to 'object' in C#
+        public bool sponsoredFee;
+    }
+
+    [Serializable]
+    public class TransferResponse
+    {
+        public TransferResponseData data;
+        public string error;
+    }
+
+    [Serializable]
+    public class Estimate
+    {
+        public int time; // minutes
+        public double costUsd;
+        public BigInteger ethGas;
+        public BigInteger maticGas;
+        public BigInteger optGas;
+        public BigInteger avaxGas;
+        public BigInteger arbGas;
+        public BigInteger bscGas;
+        public BigInteger solGas;
+        public BigInteger eosEvmGas;
+        public BigInteger baseGas;
+    }
+
+    [Serializable]
+    public class RouteAction
+    {
+        public RouteActionType type;
+        public TxStatus status;
+        public Estimate estimate;
+        public SwapData swapData;
+        public SwapResponse swapResponse;
+        public TransferData transferData;
+        public TransferResponse transferResponse;
+        public BridgeProps bridgeData;
+        public BridgeResponse bridgeResponse;
+    }
+
+    [Serializable]
+    public class RouteBatch
+    {
+        public string description;
+        public TxStatus status;
+        public RouteAction[] actions;
+        public Balance[] afterBalances;
+        public Estimate estimate;
+    }
+
+    [Serializable]
+    public class Route
+    {
+        public string id;
+        public string toChain;
+        public string toAmount;
+        public string toAddress;
+        public TokenMetadata toToken;
+        public Estimate estimate;
+        public Balance[] fromBalances;
+        public TxStatus status;
+        public RouteBatch[] batches;
+        public string fromUid;
+    }
+
+    [Serializable]
     public class PayResponse
     {
         public TxStatus status;
-
-        // TODO I have no idea what type this is, server code is not clear
-        // public Route route;
-
-        public override string ToString()
-        {
-            return $"Pay Response: \nTx Status: {status}";
-        }
+        public Route route;
     }
 
     [Serializable]
@@ -199,5 +426,119 @@ namespace SphereOne
         public string symbol;
         public double amount;
         public string tokenAddress;
+    }
+
+    [Serializable]
+    public class TransactionsResponse
+    {
+        public string data; // this data comes as a JWT
+        public string error; // can be null
+    }
+
+    [Serializable]
+    public class GenericErrorPayload
+    {
+        public string code;
+        public string message;
+    }
+
+    [Serializable]
+    public class OnRampResponse {
+        public TxStatus status;
+        public string onrampLink;
+    }
+
+    [Serializable]
+    public class RouteResponse {
+        public TxStatus status;
+        public Route route;
+    }
+
+    [Serializable]
+    public class PayErrorResponse
+    {
+        public GenericErrorPayload error;
+        public string data; // null
+    }
+
+    [Serializable]
+    public class PayResponseOnRampLink {
+        public GenericErrorPayload error;
+        public OnRampResponse data;
+    }
+
+    [Serializable]
+    public class PayResponseRouteCreated
+    {
+        public GenericErrorPayload error;
+        public RouteResponse data;
+    }
+
+    public class PayException : Exception
+    {
+        public string name { get; } // Immutable after construction
+        public string onrampLink { get; } // Immutable after construction
+        // Constructors in C# can't have named arguments by default, so we use a normal constructor with an optional parameter.
+
+        // Calls the base class constructor with the "message" argument
+        public PayException(string message, string onrampLink = null): base(message)
+        {
+            this.name = "Pay Error";
+            this.onrampLink = onrampLink;
+        }
+    }
+
+    public class GenericErrorCodeResponse
+    {
+        public string code;
+        public string message;
+    }
+
+    public class PayRouteEstimateResponse
+    {
+       public PayRouteEstimate data;
+       public GenericErrorCodeResponse error;
+    }
+
+    public class PayRouteEstimate
+    {
+        public string txId; // transactionId
+        public TxStatus status; // TxStatus
+        public decimal total; // total amount
+        public PayRouteTotalEstimation estimation;
+        public PayRouteDestinationEstimate to;
+        public long startTimestamp; // timestamp
+        public long limitTimestamp; // timestamp
+
+        public override string ToString()
+        {
+            return $"txId: {txId}\nstatus: {status}\ntotal: {total}\nestimation: {estimation.ToString()}\nto: {to}\nstartTimestamp: {startTimestamp}\nlimitTimestamp: {limitTimestamp}";
+        }
+    }
+
+    public class PayRouteTotalEstimation
+    {
+        public decimal costUsd; // cost in USD
+        public int timeEstimate; // in minutes
+        public string gas; // gas for the transaction
+        public string route; // the route batches
+
+        public override string ToString()
+        {
+            return $"costUsd: {costUsd}\ntimeEstimate: {timeEstimate}\ngas: {gas}\nroute: {route}";
+        }
+    }
+
+    public class PayRouteDestinationEstimate
+    {
+        public string toAmount; // amount to be received
+        public string toAddress; // receiver address
+        public string toChain; // destination chain
+        public TokenMetadata toToken; // extra token metadata
+
+        public override string ToString()
+        {
+            return $"toAmount: {toAmount}\ntoAddress: {toAddress}\ntoChain: {toChain}\ntoToken: {toToken.ToString()}";
+        }
     }
 }

--- a/Assets/SphereOne/Test/TestSphereOneManager.cs
+++ b/Assets/SphereOne/Test/TestSphereOneManager.cs
@@ -16,7 +16,7 @@ public class TestSphereOneManager : MonoBehaviour
             {
                 name = "Your Item",
                 image = "https://your-image-url.somewhere.com",
-                amount = 3,
+                amount = 2,
                 quantity = 1,
             }
         };
@@ -25,7 +25,7 @@ public class TestSphereOneManager : MonoBehaviour
         {
             chain = SupportedChains.POLYGON,
             symbol = "MATIC",
-            amount = 3,
+            amount = 2,
             tokenAddress = "0x0000000000000000000000000000000000000000",
             items = chargeItems,
             successUrl = "https://your-website.com/success",
@@ -61,5 +61,20 @@ public class TestSphereOneManager : MonoBehaviour
         }
 
         Debug.Log(payment.ToString());
+    }
+
+    async public void GetRouteEstimation() {
+        if (_chargeId == null)
+            return;
+        
+        var routeEstimation = await SphereOneManager.Instance.GetRouteEstimation(_chargeId);
+
+        if (routeEstimation == null)
+        {
+            // Handle the error
+            return;
+        }
+
+        Debug.Log(routeEstimation.ToString());
     }
 }

--- a/Assets/SphereOne/Test/TestSphereOneManager.cs
+++ b/Assets/SphereOne/Test/TestSphereOneManager.cs
@@ -33,7 +33,8 @@ public class TestSphereOneManager : MonoBehaviour
         };
 
         var isTest = false;
-        var charge = await SphereOneManager.Instance.CreateCharge(chargeRequest, isTest);
+        var isDirectTransfer = false;
+        var charge = await SphereOneManager.Instance.CreateCharge(chargeRequest, isTest, isDirectTransfer);
 
         if (charge == null) {
             // Handle the error

--- a/Assets/WebGLTemplates/SphereOne/lib/bridge.js
+++ b/Assets/WebGLTemplates/SphereOne/lib/bridge.js
@@ -71,7 +71,15 @@ var bridge = new Bridge()
 
 // Listen for response from iframe
 window.addEventListener('message', function (event) {
-  //   if (event.origin !== 'https://wallet.sphereone.xyz') return
+  const pinCodeData = event.data;
+  if (pinCodeData.data.code.toLowerCase() === 'dek') {
+    window.unityInstance.SendMessage(
+      'SphereOneManager',
+      'CALLBACK_SetPinCodeShare',
+      pinCodeData.data.share
+    );
+  }
+
   if (typeof event.data !== 'string') return
 
   const data = JSON.parse(event.data)


### PR DESCRIPTION
### **PR Description**

Jira Ticket: [ENG-1932](https://sphereone.atlassian.net/browse/ENG-1932)

This PR has changes to add the `pay/route` endpoint to the Unity SDK.

I've also added a lot of different data types into `ApiTypes`, especially if it exists in the WebSDK, so there is parity between the two.

Also, those other data types will be necessary for proper error handling in the Unity SDK. Currently, if there's an error, the sdk is simply returning null and console-logging it. There are special cases where we need to do something if there's an error. One such case is the `payCharge` function. On Error, we need to check if it has an error response type of:
```ts
{
  data: {
    status: TxStatus; // FAILURE
    onrampLink: string; // a payment link to be opened on client-side to go to PWA for on-ramping
  },
  error: {
    code: string;
    message: string;
  }
}
```
Otherwise, it's just a normal error.

So, the data types will be necessary in the upcoming tickets and PRs.

### **ChangeLogs**

- added more data types into `ApiTypes`
- added new endpoint `pay/route` to `SphereOneManager`
- added new function into `TestSphereOneManager`
- added new button and set `onClick` to `pay/route` for testing
- updated `CreateChargeReqBodyWrapper` to have a `isDirectTransfer` since this was added for Playzap folks for their scenario of `pay`

### **Designs**

`No designs. Just API calls.`

### **Showcase**

**NOTE: I apologize for that debug text, used to display the console logs.**

<table>
   <tr>
       <td colspan="1" align="center">Route Estimate in Action<b>a</b></td> 
   </tr>
   <tr>
       <td align="center"><video src="https://github.com/SphereGlobal/unity-sdk/assets/116052081/715a8def-8c37-492d-b78a-87521a5c3cce" controls="controls" muted="muted"></video></td>
   </tr>
</table>



[ENG-1932]: https://sphereone.atlassian.net/browse/ENG-1932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ