### PR TITLE
Hotfix - CreateCharge, Pass only Not-Nullable props for Request Payload

### DIFF
--- a/Assets/SphereOne/Scripts/ApiTypes.cs
+++ b/Assets/SphereOne/Scripts/ApiTypes.cs
@@ -98,12 +98,15 @@ namespace SphereOne
         public string tokenType;
     }
 
+#nullable enable
     [Serializable]
     public class ChargeItem
     {
-        public ChargeItem() { }
+        public ChargeItem() : this(default!, default!, default!, default!, null, null, null) { }
 
-        public ChargeItem(string name, string image, double amount, double quantity, string nftUri = "", string nftContractAddress = "", SupportedChains nftChain = SupportedChains.Unknown)
+        public ChargeItem(string name, string image, double amount, double quantity,
+                          string? nftUri = null, string? nftContractAddress = null,
+                          SupportedChains? nftChain = null)
         {
             this.name = name;
             this.image = image;
@@ -120,21 +123,23 @@ namespace SphereOne
         public double quantity;
 
         // Optional
-        public string nftUri;
-        public string nftContractAddress;
-        public SupportedChains nftChain;
+        public string? nftUri;
+        public string? nftContractAddress;
+        public SupportedChains? nftChain;
     }
 
     [Serializable]
     public class ChargeReqBody
     {
-        public ChargeReqBody() { }
+        public ChargeReqBody() : this(default!, default!, default!, default!, default!, default!, 0.0, null) { }
 
-        public ChargeReqBody(string tokenAddress, string symbol, List<ChargeItem> items, SupportedChains chain, string successUrl, string cancelUrl, double amount = 0.0, string toAddress = null)
+        public ChargeReqBody(string tokenAddress, string symbol, List<ChargeItem> items,
+                             SupportedChains chain, string successUrl, string cancelUrl,
+                             double amount = 0.0, string? toAddress = null)
         {
             this.tokenAddress = tokenAddress;
             this.symbol = symbol;
-            this.items = items;
+            this.items = items ?? new List<ChargeItem>(); // Ensure items is not null
             this.chain = chain;
             this.successUrl = successUrl;
             this.cancelUrl = cancelUrl;
@@ -151,8 +156,9 @@ namespace SphereOne
 
         // Optional
         public double amount;
-        public string toAddress;
+        public string? toAddress;
     }
+#nullable disable
 
     [Serializable]
     public class ChargeResponse

--- a/Assets/SphereOne/Scripts/SphereOneManager.cs
+++ b/Assets/SphereOne/Scripts/SphereOneManager.cs
@@ -641,16 +641,20 @@ namespace SphereOne
         /// <param name="chargeReq"></param>
         /// <param name="isTest">Not required. Determines if API Key is test or production. By default, it is false.</param>
         /// <returns>The <see cref="ChargeResponse"/> object or null if there was an error.</returns>
-        async public Task<ChargeResponse> CreateCharge(ChargeReqBody chargeReq, bool isTest = false)
+        async public Task<ChargeResponse> CreateCharge(ChargeReqBody chargeReq, bool isTest = false, bool isDirectTransfer = false)
         {
             if (_environment == Environment.EDITOR)
             {
                 // TODO fake charge mock data
                 return null;
             }
-
-            var body = new CreateChargeReqBodyWrapper(chargeReq, isTest);
-            var bodySerialized = JsonConvert.SerializeObject(body);
+            var body = new CreateChargeReqBodyWrapper(chargeReq, isTest, isDirectTransfer);
+            var settings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                DefaultValueHandling = DefaultValueHandling.Ignore
+            };
+            var bodySerialized = JsonConvert.SerializeObject(body, settings);
 
             string url = $"{_sphereOneApiUrl}/createCharge";
             var res = await WebRequestHandler.Post(url, bodySerialized, _headers);
@@ -890,7 +894,8 @@ namespace SphereOne
         public string token_type;
 
         // For Debugging, Testing
-        public override string ToString() {
+        public override string ToString()
+        {
             return $"access_token: {access_token}\nrefresh_token: {refresh_token}\nid_token: {id_token}\nscope: {scope}\nexpires_in: {expires_in}\ntoken_type: {token_type}";
         }
     }
@@ -910,7 +915,8 @@ namespace SphereOne
         }
 
         // Refresh does not work as JSON
-        public WWWForm ToForm() {
+        public WWWForm ToForm()
+        {
             WWWForm form = new WWWForm();
             form.AddField("grant_type", grant_type);
             form.AddField("refresh_token", refresh_token);
@@ -959,13 +965,15 @@ namespace SphereOne
     [Serializable]
     class CreateChargeReqBodyWrapper
     {
-        public CreateChargeReqBodyWrapper(ChargeReqBody chargeData, bool isTest)
+        public CreateChargeReqBodyWrapper(ChargeReqBody chargeData, bool isTest, bool isDirectTransfer)
         {
             this.isTest = isTest;
+            this.isDirectTransfer = isDirectTransfer;
             this.chargeData = chargeData;
         }
 
         public bool isTest;
+        public bool isDirectTransfer;
         public ChargeReqBody chargeData;
     }
 


### PR DESCRIPTION
### **PR Description**

**HOTFIX**: This PR has changes to update the `CreateCharge` function and pass in only the not-null props when making the API call.

There were some server validations added, checking for `optional` - `undefined` - only. So, have added this hot-fix on Unity side.

### **ChangeLogs**

- added `#nullable` macro and updated `ChargeItem` and `ChargeReqBody` to be able to have `nullable` fields when instantiating the classes
- added `JsonSerializerSettings` when serializing an object before making an API call for `createCharge` to ignore and not include fields with `null` values


### **Showcase**

<table>
   <tr>
       <td colspan="1" align="center"><b>Hotfix for CreateCharge in Unity</b></td> 
   </tr>
   <tr>
       <td align="center">The Issue</td>
   </tr>
   <tr>
       <td align="center"><video src="https://github.com/SphereGlobal/unity-sdk/assets/116052081/7e9a1571-66b1-47d3-985a-83f774b9a1e5" controls="controls" muted="muted"></video></td>
   </tr>
   <tr>
       <td align="center">The Fix</td>
   </tr>
   <tr>
       <td align="center"><video src="https://github.com/SphereGlobal/unity-sdk/assets/116052081/b0eaca19-e3a9-4e68-b6cd-c1162858ab6a" controls="controls" muted="muted"></video></td>
   </tr>
</table>





